### PR TITLE
Adding task.standardInput = FileHandle.nullDevice to default executor

### DIFF
--- a/Sources/Run/CommandExecutor.swift
+++ b/Sources/Run/CommandExecutor.swift
@@ -49,6 +49,7 @@ class ActualTaskExecutor: TaskExecutor {
 
         task.standardOutput = stdoutPipe
         task.standardError = stderrPipe
+        task.standardInput = FileHandle.nullDevice
         task.launch()
         task.waitUntilExit()
 


### PR DESCRIPTION
Hey, I was using this to run FFMpeg commands and noticed it hanging on commands that expected input. As this is not the interactive case, I have added 

```swift
task.standardInput = FileHandle.nullDevice
```
to the `ActualTaskExecutor`, so that the task is expecting no input. I am not sure if this will have any adverse effects but it works for all the commands I have run, but only tested on macOS.